### PR TITLE
fix: replace static salt with cryptographically secure random salt

### DIFF
--- a/app/src/main/java/com/minikano/f50_sms/utils/PassHash.kt
+++ b/app/src/main/java/com/minikano/f50_sms/utils/PassHash.kt
@@ -11,10 +11,9 @@ object PassHash {
     /** 生成随机盐 */
     fun generateSalt(bytes: Int = 16): ByteArray {
         require(bytes >= 16) { "salt bytes should be >= 16" }
-        val fixedHex = "yPRdRTAqha8aceR8eMxcuP78uCFa"
-        val fixed = fixedHex.chunked(2).map { it.toInt(16).toByte() }.toByteArray()
-        return fixed
-        //return ByteArray(bytes).also { rng.nextBytes(it) }
+        val salt = ByteArray(bytes)
+        rng.nextBytes(salt)
+        return salt
     }
 
     /**


### PR DESCRIPTION
Replaced the hardcoded, static salt in `PassHash.kt` with a cryptographically secure, randomly generated salt using `SecureRandom`. The previous implementation relied on a fixed hex string, which effectively functioned as a pepper rather than a salt, failing to provide the intended protection against rainbow table and dictionary attacks. 

Technical impact:
1. Improved security: Ensures that every password hash is unique, significantly raising the cost of offline cracking attempts.
2. Bug fix: Corrected an issue where the static salt size (14 bytes) violated the enforced constraint of a minimum of 16 bytes for salt length.

Note: This change will invalidate existing password hashes stored using the previous static salt implementation.