### PR TITLE
fix:修复README中Star History图表无法显示的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ Magisk 模块版本（畅行60 / 云电脑）安装教程：[📺 B站视频](ht
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=kanoqwq%2FUFI-TOOLS&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#kanoqwq/UFI-TOOLS&type=date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=kanoqwq/UFI-TOOLS&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=kanoqwq/UFI-TOOLS&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/image?repos=kanoqwq/UFI-TOOLS&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=kanoqwq/UFI-TOOLS&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=kanoqwq/UFI-TOOLS&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=kanoqwq/UFI-TOOLS&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
原有的 Star History 图表因 GitHub stargazer API 限制已经失效，无法正常展示。本 MR 将图表切换到新的数据源 star-history.dera.page，无需 API token 即可正常显示项目 star 历史，保证 README 展示效果。